### PR TITLE
ABZ-23647 introduce code analysers for public APIs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,3 +4,7 @@
 # We can set the severity for compiler warnings or analyzer rules in an EditorConfig file with the following syntax:
 # dotnet_diagnostic.<rule ID>.severity = <severity>
 # for more details please refer https://docs.microsoft.com/en-us/visualstudio/code-quality/use-roslyn-analyzers?view=vs-2019
+
+
+# RS0016: Add public types and members to the declared API
+dotnet_diagnostic.RS0016.severity = silent

--- a/FileShareAdminClient/FileShareAdminClient.csproj
+++ b/FileShareAdminClient/FileShareAdminClient.csproj
@@ -12,6 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.Runtime" Version="4.3.1" />
   </ItemGroup>
 

--- a/FileShareAdminClient/FileShareApiAdminClient.cs
+++ b/FileShareAdminClient/FileShareApiAdminClient.cs
@@ -44,6 +44,7 @@ namespace UKHO.FileShareAdminClient
     {
         private readonly int maxFileBlockSize;
 
+#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
         public FileShareApiAdminClient(IHttpClientFactory httpClientFactory, string baseAddress, string accessToken,
             int maxFileBlockSize = 4194304) : base(httpClientFactory, baseAddress, accessToken)
         {
@@ -61,6 +62,7 @@ namespace UKHO.FileShareAdminClient
         {
             this.maxFileBlockSize = maxFileBlockSize;
         }
+#pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
 
         public async Task<IResult<AppendAclResponse>> AppendAclAsync(string batchId, Acl acl,
             CancellationToken cancellationToken = default)

--- a/FileShareClient/FileShareClient.csproj
+++ b/FileShareClient/FileShareClient.csproj
@@ -12,6 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.14" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />


### PR DESCRIPTION
The added Microsoft.CodeAnalysis.PublicApiAnalyzers reference is a private asset and is not included (and does not alter) the resultant nuget 