### PR TITLE
Remove concrete casts for BatchHandle

### DIFF
--- a/FileShareAdminClient/FileShareApiAdminClient.cs
+++ b/FileShareAdminClient/FileShareApiAdminClient.cs
@@ -139,7 +139,7 @@ namespace UKHO.FileShareAdminClient
             var uri = $"/batch/{batchHandle.BatchId}";
             var batchCommitModel = new BatchCommitModel
             {
-                FileDetails = ((BatchHandle)batchHandle).FileDetails
+                FileDetails = batchHandle.FileDetails
             };
 
             var payloadJson = JsonConvert.SerializeObject(batchCommitModel.FileDetails);
@@ -158,7 +158,7 @@ namespace UKHO.FileShareAdminClient
             var uri = $"/batch/{batchHandle.BatchId}";
             var batchCommitModel = new BatchCommitModel
             {
-                FileDetails = ((BatchHandle)batchHandle).FileDetails
+                FileDetails = batchHandle.FileDetails
             };
             return await SendResult<List<FileDetail>, CommitBatchResponse>(uri, HttpMethod.Put, batchCommitModel.FileDetails, cancellationToken,
                 HttpStatusCode.Accepted);
@@ -275,7 +275,7 @@ namespace UKHO.FileShareAdminClient
                     writeFileResponse.EnsureSuccessStatusCode();
                 }
             }
-            ((BatchHandle)batchHandle).AddFile(fileName, Convert.ToBase64String(md5Hash));
+            batchHandle.AddFile(fileName, Convert.ToBase64String(md5Hash));
         }
         private async Task<IResult<AddFileToBatchResponse>> AddFiles(IBatchHandle batchHandle, Stream stream, string fileName, string mimeType,
             Action<(int blocksComplete, int totalBlockCount)> progressUpdate, CancellationToken cancellationToken,
@@ -356,7 +356,7 @@ namespace UKHO.FileShareAdminClient
                         }
                         else
                         {
-                            ((BatchHandle)batchHandle).AddFile(fileName, Convert.ToBase64String(md5Hash));
+                            batchHandle.AddFile(fileName, Convert.ToBase64String(md5Hash));
                             return result;
                         }
                     }

--- a/FileShareAdminClient/Models/BatchHandle.cs
+++ b/FileShareAdminClient/Models/BatchHandle.cs
@@ -5,6 +5,8 @@ namespace UKHO.FileShareAdminClient.Models
     public interface IBatchHandle
     {
         string BatchId { get; }
+        List<FileDetail> FileDetails { get; }
+        void AddFile(string filename, string hash);
     }
 
     internal class BatchHandle : IBatchHandle
@@ -18,9 +20,9 @@ namespace UKHO.FileShareAdminClient.Models
             BatchId = batchId;
         }
 
-        internal void AddFile(string filename, string hash)
+        public void AddFile(string filename, string hash)
         {
-            FileDetails.Add(new FileDetail {FileName = filename, Hash = hash});
+            FileDetails.Add(new FileDetail { FileName = filename, Hash = hash });
         }
     }
 }


### PR DESCRIPTION
As the client methods are taking an interface arg, we should stop casting to an internal implementation of BatchHandle in code.

Change is required for work on CDS, which is adopting this client nuget.

Co-Authored-By: Samir Hassoun <51328831+SamirHassoun@users.noreply.github.com>