### PR TITLE
45744 Maritime Safety Information - FSS DotNet Client - Add method for GetFilesAsZip endpoint

### DIFF
--- a/FileShareClient/FileShareApiClient.cs
+++ b/FileShareClient/FileShareApiClient.cs
@@ -220,7 +220,7 @@ namespace UKHO.FileShareClient
             using (var httpClient = await GetAuthenticationHeaderSetClient())
             using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, uri))
             {
-                var response = await httpClient.SendAsync(httpRequestMessage, CancellationToken.None);
+                var response = await httpClient.SendAsync(httpRequestMessage, cancellationToken);
                 response.EnsureSuccessStatusCode();
                 var downloadedFileStream = await response.Content.ReadAsStreamAsync();
                 return downloadedFileStream;

--- a/FileShareClient/FileShareApiClient.cs
+++ b/FileShareClient/FileShareApiClient.cs
@@ -24,7 +24,7 @@ namespace UKHO.FileShareClient
         Task<IResult<DownloadFileResponse>> DownloadFileAsync(string batchId, string fileName, Stream destinationStream, long fileSizeInBytes = 0, CancellationToken cancellationToken = default);
 
         Task<IEnumerable<string>> GetUserAttributesAsync();
-        Task<Stream> DownloadZipFileAsync(string batchId, CancellationToken cancellationToken = default);
+        Task<Stream> DownloadZipFileAsync(string batchId, CancellationToken cancellationToken);
     }
 
     public class FileShareApiClient : IFileShareApiClient

--- a/FileShareClient/FileShareApiClient.cs
+++ b/FileShareClient/FileShareApiClient.cs
@@ -24,6 +24,7 @@ namespace UKHO.FileShareClient
         Task<IResult<DownloadFileResponse>> DownloadFileAsync(string batchId, string fileName, Stream destinationStream, long fileSizeInBytes = 0, CancellationToken cancellationToken = default);
 
         Task<IEnumerable<string>> GetUserAttributesAsync();
+        Task<Stream> DownloadZipFileAsync(string batchId, CancellationToken cancellationToken = default);
     }
 
     public class FileShareApiClient : IFileShareApiClient
@@ -212,6 +213,19 @@ namespace UKHO.FileShareClient
             return result;
         }
 
+        public async Task<Stream> DownloadZipFileAsync(string batchId, CancellationToken cancellationToken)
+        {
+            var uri = $"batch/{batchId}/files";
+
+            using (var httpClient = await GetAuthenticationHeaderSetClient())
+            using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, uri))
+            {
+                var response = await httpClient.SendAsync(httpRequestMessage, CancellationToken.None);
+                response.EnsureSuccessStatusCode();
+                var downloadedFileStream = await response.Content.ReadAsStreamAsync();
+                return downloadedFileStream;
+            }
+        }
 
         #region private methods
         private static string AddQueryString(string uri, IEnumerable<KeyValuePair<string, string>> queryString)
@@ -233,7 +247,7 @@ namespace UKHO.FileShareClient
             }
 
             return sb.ToString();
-        }
+        }        
         #endregion
 
     }

--- a/FileShareClient/FileShareApiClient.cs
+++ b/FileShareClient/FileShareApiClient.cs
@@ -24,7 +24,7 @@ namespace UKHO.FileShareClient
         Task<IResult<DownloadFileResponse>> DownloadFileAsync(string batchId, string fileName, Stream destinationStream, long fileSizeInBytes = 0, CancellationToken cancellationToken = default);
 
         Task<IEnumerable<string>> GetUserAttributesAsync();
-        Task<Stream> DownloadZipFileAsync(string batchId, CancellationToken cancellationToken);
+        Task<IResult<Stream>> DownloadZipFileAsync(string batchId, CancellationToken cancellationToken);
     }
 
     public class FileShareApiClient : IFileShareApiClient
@@ -213,18 +213,19 @@ namespace UKHO.FileShareClient
             return result;
         }
 
-        public async Task<Stream> DownloadZipFileAsync(string batchId, CancellationToken cancellationToken)
+        public async Task<IResult<Stream>> DownloadZipFileAsync(string batchId, CancellationToken cancellationToken)
         {
             var uri = $"batch/{batchId}/files";
+            var result = new Result<Stream>();
+            HttpStatusCode httpStatusCode = HttpStatusCode.OK;
 
             using (var httpClient = await GetAuthenticationHeaderSetClient())
             using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, uri))
             {
-                var response = await httpClient.SendAsync(httpRequestMessage, cancellationToken);
-                response.EnsureSuccessStatusCode();
-                var downloadedFileStream = await response.Content.ReadAsStreamAsync();
-                return downloadedFileStream;
+                var response = await httpClient.SendAsync(httpRequestMessage, cancellationToken);                
+                await result.ProcessHttpResponse(httpStatusCode, response, true);                
             }
+            return result;
         }
 
         #region private methods

--- a/FileShareClient/FileShareApiClient.cs
+++ b/FileShareClient/FileShareApiClient.cs
@@ -223,7 +223,12 @@ namespace UKHO.FileShareClient
             using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, uri))
             {
                 var response = await httpClient.SendAsync(httpRequestMessage, cancellationToken);                
-                await result.ProcessHttpResponse(httpStatusCode, response, true);                
+                await result.ProcessHttpResponse(httpStatusCode, response, true);
+                if (result.IsSuccess)
+                {
+                    result.Data = response.ReadAsStreamAsync().Result;
+                    return result;
+                }
             }
             return result;
         }

--- a/Tests/UnitTests/FileShareClientTests/DownloadFilesTests.cs
+++ b/Tests/UnitTests/FileShareClientTests/DownloadFilesTests.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using UKHO.FileShareClient;
+using UKHO.FileShareClient.Models;
 using UKHO.FileShareClientTests.Helpers;
 
 namespace UKHO.FileShareClientTests
@@ -238,11 +239,16 @@ namespace UKHO.FileShareClientTests
         public async Task TestBasicDownloadZipFile()
         {
             var batchId = Guid.NewGuid().ToString();
-            var expectedBytes = Encoding.UTF8.GetBytes("Contents of a file.");
-            nextResponse = new MemoryStream(expectedBytes);
+            
+            IResult<Stream> expectedBytes = new Result<Stream>
+            {
+                Data = new MemoryStream(Encoding.UTF8.GetBytes("Contents of a file."))
+            };
+            nextResponse = expectedBytes.Data;
 
             var response = await fileShareApiClient.DownloadZipFileAsync(batchId, CancellationToken.None);
 
+            Assert.AreEqual(expectedBytes.Data, response.Data);
             Assert.AreEqual((int)nextResponseStatusCode, response.StatusCode);
             Assert.IsTrue(response.IsSuccess);
             Assert.AreEqual($"/basePath/batch/{batchId}/files", lastRequestUri.AbsolutePath);

--- a/Tests/UnitTests/FileShareClientTests/DownloadFilesTests.cs
+++ b/Tests/UnitTests/FileShareClientTests/DownloadFilesTests.cs
@@ -241,8 +241,10 @@ namespace UKHO.FileShareClientTests
             var expectedBytes = Encoding.UTF8.GetBytes("Contents of a file.");
             nextResponse = new MemoryStream(expectedBytes);
 
-            var batchStatusResponse = await fileShareApiClient.DownloadZipFileAsync(batchId, CancellationToken.None);
-            Assert.AreEqual(expectedBytes, ((MemoryStream)batchStatusResponse).ToArray());
+            var response = await fileShareApiClient.DownloadZipFileAsync(batchId, CancellationToken.None);
+
+            Assert.AreEqual((int)nextResponseStatusCode, response.StatusCode);
+            Assert.IsTrue(response.IsSuccess);
             Assert.AreEqual($"/basePath/batch/{batchId}/files", lastRequestUri.AbsolutePath);
         }
 
@@ -250,19 +252,12 @@ namespace UKHO.FileShareClientTests
         public async Task TestDownloadZipFileForABatchThatDoesNotExist()
         {
             var batchId = Guid.NewGuid().ToString();
-
             nextResponseStatusCode = HttpStatusCode.BadRequest;
 
-            try
-            {
-                await fileShareApiClient.DownloadZipFileAsync(batchId, CancellationToken.None);
-                Assert.Fail("Expected to throw an exception");
-            }
-            catch (Exception e)
-            {
-                Assert.IsInstanceOf<HttpRequestException>(e);
-            }
+            var response = await fileShareApiClient.DownloadZipFileAsync(batchId, CancellationToken.None);
 
+            Assert.AreEqual((int)nextResponseStatusCode, response.StatusCode);
+            Assert.IsFalse(response.IsSuccess);
             Assert.AreEqual($"/basePath/batch/{batchId}/files", lastRequestUri.AbsolutePath);
         }
 
@@ -270,19 +265,12 @@ namespace UKHO.FileShareClientTests
         public async Task TestDownloadZipFileForABatchWithAFileThatDoesNotExist()
         {
             var batchId = Guid.NewGuid().ToString();
-
             nextResponseStatusCode = HttpStatusCode.NotFound;
 
-            try
-            {
-                await fileShareApiClient.DownloadZipFileAsync(batchId, CancellationToken.None);
-                Assert.Fail("Expected to throw an exception");
-            }
-            catch (Exception e)
-            {
-                Assert.IsInstanceOf<HttpRequestException>(e);
-            }
+            var response = await fileShareApiClient.DownloadZipFileAsync(batchId, CancellationToken.None);
 
+            Assert.AreEqual((int)nextResponseStatusCode, response.StatusCode);
+            Assert.IsFalse(response.IsSuccess);
             Assert.AreEqual($"/basePath/batch/{batchId}/files", lastRequestUri.AbsolutePath);
         }
 
@@ -290,19 +278,12 @@ namespace UKHO.FileShareClientTests
         public async Task TestGetBatchStatusForABatchZipFileThatHasBeenDeleted()
         {
             var batchId = Guid.NewGuid().ToString();
-
             nextResponseStatusCode = HttpStatusCode.Gone;
 
-            try
-            {
-                await fileShareApiClient.DownloadZipFileAsync(batchId, CancellationToken.None);
-                Assert.Fail("Expected to throw an exception");
-            }
-            catch (Exception e)
-            {
-                Assert.IsInstanceOf<HttpRequestException>(e);
-            }
+            var response = await fileShareApiClient.DownloadZipFileAsync(batchId, CancellationToken.None);
 
+            Assert.AreEqual((int)nextResponseStatusCode, response.StatusCode);
+            Assert.IsFalse(response.IsSuccess);            
             Assert.AreEqual($"/basePath/batch/{batchId}/files", lastRequestUri.AbsolutePath);
         }
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ variables:
   - name: UKHOAssemblyCompany
     value: "UK Hydrographic Office"
   - name: UKHOAssemblyVersionPrefix
-    value: "1.3."
+    value: "1.4."
   - name: UKHOAssemblyProduct
     value: "File Share Dotnet Client"
   - name: coverityPool


### PR DESCRIPTION
Hi All, please review and merge changes related to PBI:45744 - Task:48544 - To add method for GetFilesAsZip endpoint to be used for download daily notices to mariners zip file in Maritime Safety Information.