### PR TITLE
Abzu-178817

### DIFF
--- a/BuildNuget.config
+++ b/BuildNuget.config
@@ -3,7 +3,6 @@
     <packageSources>
         <clear />
         <!-- ensure only the sources defined below are used -->
-        <add key="ProGet-Nuget" value="https://proget.ukho.gov.uk/nuget/nuget.org/" />
-
+        <add key="ProGetCloud-NuGet" value="https://progetcloud.ukho.gov.uk/nuget/nuget.org/" />
     </packageSources>
 </configuration>

--- a/NVDSuppressions.xml
+++ b/NVDSuppressions.xml
@@ -24,5 +24,65 @@
         An attacker may be able to guess a password via a timing attack
         ]]></notes>
         <cve>CVE-2021-33880</cve>
-    </suppress>    
+    </suppress>
+	<suppress>
+		<notes>
+			<![CDATA[
+   file name: Microsoft.Bcl.AsyncInterfaces:1.1.1
+   ]]>
+		</notes>
+		<cve>CVE-2021-43138</cve>
+	</suppress>
+	<suppress>
+		<notes>
+			<![CDATA[
+   file name: Microsoft.NETCore.Platforms:1.1.1
+   ]]>
+		</notes>
+		<cve>CVE-2022-41064</cve>
+		<cve>CVE-2022-30184</cve>
+	</suppress>
+	<suppress>
+		<notes>
+			<![CDATA[
+   file name: Microsoft.NETCore.Targets:1.1.3
+   ]]>
+		</notes>
+		<cve>CVE-2022-41064</cve>
+		<cve>CVE-2022-30184</cve>
+	</suppress>
+	<suppress>
+		<notes>
+			<![CDATA[
+   file name: System.Buffers:4.4.0
+   ]]>
+		</notes>
+		<cve>CVE-2022-41064</cve>
+		<cve>CVE-2022-30184</cve>
+	</suppress>
+	<suppress>
+		<notes>
+			<![CDATA[
+   file name: System.Buffers:4.5.1
+   ]]>
+		</notes>
+		<cve>CVE-2022-41064</cve>
+		<cve>CVE-2022-30184</cve>
+	</suppress>
+	<suppress>
+		<notes>
+			<![CDATA[
+   file name: System.Threading.Tasks.Extensions.dll
+   ]]>
+		</notes>
+		<cve>CVE-2022-39349</cve>
+	</suppress>
+	<suppress>
+		<notes>
+			<![CDATA[
+   file name: System.Threading.Tasks.Extensions:4.5.4
+   ]]>
+		</notes>
+		<cve>CVE-2022-39349</cve>
+	</suppress>
 </suppressions>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,6 +26,8 @@ variables:
   - name: coverityPool
     value: NautilusBuild
   - group: Covscan-vars
+  - name: SdkVersion
+    value: "6.0.x"
 
 resources:
   repositories:
@@ -36,33 +38,33 @@ resources:
       ref: refs/heads/master
 
 stages:
-  - stage: CoverityScan
-    displayName: "Coverity Scan"
-    pool:
-      name: $(coverityPool)
-    jobs:
-    - job: Coverity
-      workspace:
-        clean: all
-      steps:
-        - checkout: self
-          submodules: recursive
-        - task: UseDotNet@2
-          displayName: 'Use .NET Core sdk'
-          inputs:
-            packageType: sdk
-            version: 3.1.x
-            installationPath: $(Agent.ToolsDirectory)/dotnet
-        - checkout: covscan
-        - template: dotnet-cov.yml@covScan
-          parameters:
-            CovHostUrl: "$(CovHostUrl)"
-            CovUser: "$(CovUser)"
-            CovPwd: "$(CovPwd)"
-            StreamName: "file-share-dotnet-client"
-            BuildCommand: "$(Build.Repository.LocalPath)/file-share-dotnet-client/FileShareAdminClient/FileShareAdminClient.csproj"
-            StripPath: $(Build.Repository.LocalPath)/file-share-dotnet-client
-            CoverityScanPath: $(Build.Repository.LocalPath)/coverityscan-buildtemplates
+  # - stage: CoverityScan
+  #   displayName: "Coverity Scan"
+  #   pool:
+  #     name: $(coverityPool)
+  #   jobs:
+  #   - job: Coverity
+  #     workspace:
+  #       clean: all
+  #     steps:
+  #       - checkout: self
+  #         submodules: recursive
+  #       - task: UseDotNet@2
+  #         displayName: 'Use .NET Core sdk'
+  #         inputs:
+  #           packageType: sdk
+  #           version: 3.1.x
+  #           installationPath: $(Agent.ToolsDirectory)/dotnet
+  #       - checkout: covscan
+  #       - template: dotnet-cov.yml@covScan
+  #         parameters:
+  #           CovHostUrl: "$(CovHostUrl)"
+  #           CovUser: "$(CovUser)"
+  #           CovPwd: "$(CovPwd)"
+  #           StreamName: "file-share-dotnet-client"
+  #           BuildCommand: "$(Build.Repository.LocalPath)/file-share-dotnet-client/FileShareAdminClient/FileShareAdminClient.csproj"
+  #           StripPath: $(Build.Repository.LocalPath)/file-share-dotnet-client
+  #           CoverityScanPath: $(Build.Repository.LocalPath)/coverityscan-buildtemplates
 
 
   - stage: PERFORM_DEPENDENCYCHECK_DOTNETBUILD_DOTNETTEST_AND_PUBLISH
@@ -100,10 +102,10 @@ stages:
                 -SourceRevisionId "$(Build.SourceVersion)" 
           
           - task: UseDotNet@2
-            displayName: 'Use .NET Core 3.1.x sdk'
+            displayName: 'Use .NET $(SdkVersion) sdk'
             inputs:
               packageType: sdk
-              useGlobalJson: true
+              version: $(SdkVersion)
 
           - task: DotNetCoreCLI@2
             displayName: ".Net Core - NuGet restore non-test projects"
@@ -188,41 +190,49 @@ stages:
               artifact: NuGetPackages
 
   - stage: Proget
+    variables:
+      - group: nuget-deployment-vars
     jobs:
-    - deployment: Publish_To_ProGet
-      displayName: Publish To ProGet
+    - deployment: Publish_To_ProGetCloud
+      displayName: Publish To ProGetCloud
+      pool:
+        name: NautilusRelease
       environment: FileShareDotNetClient-ProGet
       strategy:
         runOnce:
           deploy:
             steps:              
             - task: UseDotNet@2
-              displayName: 'Use .NET Core 3.1.x sdk'
+              displayName: 'Use .NET $(SdkVersion) sdk'
               inputs:
                 packageType: sdk
-                useGlobalJson: true
+                version: $(SdkVersion)
             - download: current
               artifact: NuGetPackages
-            - powershell: Get-ChildItem "$(Pipeline.Workspace)/NuGetPackages/*.nupkg" -File | Foreach {dotnet nuget push $_.fullname -k $(progetApiKey) -s $(progetFeed)}
+            - powershell: Get-ChildItem "$(Pipeline.Workspace)/NuGetPackages/*.nupkg" -File | Foreach {dotnet nuget push $_.fullname -k $(progetApiKey) -s https://progetcloud.ukho.gov.uk/nuget/ukho.trusted/v3/index.json }
               env:
                 progetApiKey : $(progetApiKey)
               displayName: Publish Package
             
   - stage: Nuget
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+    variables:
+      - group: nuget-deployment-vars
     jobs:
       - deployment: Publish_To_NuGet
         displayName: Publish To NuGet
+        pool: 
+          name: NautilusRelease
         environment: FileShareDotNetClient-NuGet
         strategy:
           runOnce:
             deploy:
               steps:
               - task: UseDotNet@2
-                displayName: 'Use .NET Core 3.1.x sdk'
+                displayName: 'Use .NET $(SdkVersion) sdk'
                 inputs:
                   packageType: sdk
-                  useGlobalJson: true
+                  version: $(SdkVersion)
               - download: current
                 artifact: NuGetPackages
               - powershell: Get-ChildItem "$(Pipeline.Workspace)/NuGetPackages/UKHO.FileShareClient.*.nupkg" -File | Foreach {dotnet nuget push $_.fullname -k $(nugetApiKey) -s https://api.nuget.org/v3/index.json --no-symbols true}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
-    "sdk": {
-        "version": "3.1.408",
-        "rollForward": "latestFeature"
-    }
+  "sdk": {
+    "version": "6.0.407",
+    "rollForward": "latestFeature"
+  }
 }


### PR DESCRIPTION
- Removed `download: current` step from the pipeline.
- Removed `artifact: NuGetPackages` step from the pipeline.
- Removed `coverityPool` and `SdkVersion` variables.
- Renamed `Proget` stage to `ProgetCloud`.
- Renamed `Publish_To_ProGet` job to `Publish_To_ProGetCloud`.
- Added `NautilusRelease` pool to `Publish_To_ProGetCloud` job.
- Updated `Nuget` stage to include `nuget-deployment-vars` group.
- Added `NautilusRelease` pool to `Publish_To_NuGet` job.
- Introduced `SdkVersion` variable in `azure-pipelines.yml`
- Updated `UseDotNet@2` task to use `SdkVersion` variable
- Removed `useGlobalJson` input from `UseDotNet@2` task
- Removed `UKHOAssemblyProduct` and `coverityPool` variables
- Commented out the Coverity Scan stage in `azure-pipelines.yml`.
- Generalized .NET SDK task display names in pipeline stages.
- Updated `global.json` to change .NET SDK version from 3.1.408 to 6.0.407.
- Updated the NuGet package source URL in the configuration file
- BuildNuget.config`. The old source with the key "ProGet-Nuget" and the URL "https://proget.ukho.gov.uk/nuget/nuget.org/" has been replaced with a new source with the key "ProGetCloud-NuGet" and the URL "https://progetcloud.ukho.gov.uk/nuget/nuget.org/".