### PR TITLE
Update FileTransform task in integration-test.yml

### DIFF
--- a/Deployment/integration-test.yml
+++ b/Deployment/integration-test.yml
@@ -7,7 +7,7 @@ steps:
   displayName: File transform - ${{ parameters.BuildTaskFramework }}
   inputs:
     folderPath: $(Pipeline.Workspace)\IntegrationTests\${{ parameters.BuildTaskFramework }}
-    xmlTransformationRules:
+    enableXmlTransform: false
     jsonTargetFiles: 'appsettings.json'
 
 - task: DotNetCoreCLI@2


### PR DESCRIPTION
Modified the FileTransform@2 task in the integration-test.yml file:
- Removed the `xmlTransformationRules` input.
- Added a new input `enableXmlTransform` with the value set to `false`.

This change affects how XML transformations are handled during integration tests.