### PR TITLE
Keep upload streams open

### DIFF
--- a/FileShareAdminClient/FileShareApiAdminClient.cs
+++ b/FileShareAdminClient/FileShareApiAdminClient.cs
@@ -300,7 +300,7 @@ namespace UKHO.FileShareAdminClient
             var buffer = new byte[_maxFileBlockSize];
 
             using (var md5 = MD5.Create())
-            using (var cryptoStream = new CryptoStream(stream, md5, CryptoStreamMode.Read))
+            using (var cryptoStream = new CryptoStream(stream, md5, CryptoStreamMode.Read, true))
             {
                 while (true)
                 {
@@ -385,7 +385,7 @@ namespace UKHO.FileShareAdminClient
                     var buffer = new byte[_maxFileBlockSize];
 
                     using (var md5 = MD5.Create())
-                    using (var cryptoStream = new CryptoStream(stream, md5, CryptoStreamMode.Read))
+                    using (var cryptoStream = new CryptoStream(stream, md5, CryptoStreamMode.Read, true))
                     {
                         while (true)
                         {

--- a/FileShareClient/FileShareClient.csproj
+++ b/FileShareClient/FileShareClient.csproj
@@ -17,9 +17,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="9.0.0" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
   </ItemGroup>
 
 </Project>

--- a/NVDSuppressions.xml
+++ b/NVDSuppressions.xml
@@ -8,6 +8,7 @@
    ]]>
     </notes>
     <packageUrl regex="true">^pkg:nuget/UKHO\.FileShareAdminClient@.*$</packageUrl>
+    <cvssBelow>11</cvssBelow>
   </suppress>
   <suppress>
     <notes>

--- a/NVDSuppressions.xml
+++ b/NVDSuppressions.xml
@@ -3,12 +3,24 @@
   <suppress>
     <notes>
       <![CDATA[
+   file name: UKHO.FileShareAdminClient:any
+   Suppress all vulnerabilities for this package as it is the old version of the package we're trying to build.
+   ]]>
+    </notes>
+    <packageUrl regex="true">^pkg:nuget/UKHO\.FileShareAdminClient@.*$</packageUrl>
+    <cpe>cpe:/a:file:file</cpe>
+    <cpe>cpe:/a:file_project:file</cpe>
+  </suppress>
+  <suppress>
+    <notes>
+      <![CDATA[
    file name: UKHO.FileShareClient:any
    Suppress all vulnerabilities for this package as it is the old version of the package we're trying to build.
    ]]>
     </notes>
     <packageUrl regex="true">^pkg:nuget/UKHO\.FileShareClient@.*$</packageUrl>
     <cpe>cpe:/a:file:file</cpe>
+    <cpe>cpe:/a:file_project:file</cpe>
   </suppress>
   <suppress>
     <notes>

--- a/NVDSuppressions.xml
+++ b/NVDSuppressions.xml
@@ -3,6 +3,15 @@
   <suppress>
     <notes>
       <![CDATA[
+   file name: UKHO.FileShareAdminClient:any
+   Suppress all vulnerabilities for this package as it is the old version of the package we're trying to build.
+   ]]>
+    </notes>
+    <packageUrl regex="true">^pkg:nuget/UKHO\.FileShareAdminClient@.*$</packageUrl>
+  </suppress>
+  <suppress>
+    <notes>
+      <![CDATA[
    file name: System.Buffers:4.5.1
    CVE-2022-41064 applies to System.Data.SqlClient/Microsoft.Data.SqlClient (not used). See https://github.com/dotnet/announcements/issues/239
    CVE-2022-30184 patched in latest .NET Core 3.1/.NET 6 versions. See https://msrc.microsoft.com/update-guide/en-US/vulnerability/CVE-2022-30184
@@ -21,18 +30,6 @@
    ]]>
     </notes>
     <packageUrl regex="true">^pkg:generic/System\.Threading\.Tasks\.Extensions@.*$</packageUrl>
-    <cve>CVE-2020-22475</cve>
-    <cve>CVE-2022-39349</cve>
-  </suppress>
-  <suppress>
-    <notes>
-      <![CDATA[
-   file name: System.Threading.Tasks.Extensions:4.5.4
-   CVE-2020-22475 applies to Tasks.org Android app. See https://nvd.nist.gov/vuln/detail/CVE-2020-22475
-   CVE-2022-39349 applies to Tasks.org Android app. See https://securitylab.github.com/advisories/GHSL-2022-062_Tasks_org
-   ]]>
-    </notes>
-    <packageUrl regex="true">^pkg:nuget/System\.Threading\.Tasks\.Extensions@.*$</packageUrl>
     <cve>CVE-2020-22475</cve>
     <cve>CVE-2022-39349</cve>
   </suppress>

--- a/NVDSuppressions.xml
+++ b/NVDSuppressions.xml
@@ -56,4 +56,24 @@
     <packageUrl regex="true">^pkg:nuget/System\.Text\.Json@.*$</packageUrl>
     <vulnerabilityName>CVE-2024-43485</vulnerabilityName>
   </suppress>
+  <suppress>
+    <notes>
+      <![CDATA[
+   file name: Various
+   Applies to mobile apps.
+   ]]>
+    </notes>
+    <cve>CVE-2020-22475</cve>
+    <cve>CVE-2022-39349</cve>
+  </suppress>
+  <suppress>
+    <notes>
+      <![CDATA[
+   file name: Microsoft.JScript.dll
+   Applies to old vulnerability in browsers. See https://msrc.microsoft.com/update-guide/en-US/advisory/CVE-2016-3202
+   ]]>
+    </notes>
+    <packageUrl regex="true">^pkg:generic/Microsoft\.JScript@.*$</packageUrl>
+    <cve>CVE-2016-3202</cve>
+  </suppress>
 </suppressions>

--- a/NVDSuppressions.xml
+++ b/NVDSuppressions.xml
@@ -8,7 +8,7 @@
    ]]>
     </notes>
     <packageUrl regex="true">^pkg:nuget/UKHO\.FileShareAdminClient@.*$</packageUrl>
-    <cvssBelow>11</cvssBelow>
+    <cvssBelow>10.0</cvssBelow>
   </suppress>
   <suppress>
     <notes>

--- a/NVDSuppressions.xml
+++ b/NVDSuppressions.xml
@@ -3,12 +3,12 @@
   <suppress>
     <notes>
       <![CDATA[
-   file name: UKHO.FileShareAdminClient:any
+   file name: UKHO.FileShareClient:any
    Suppress all vulnerabilities for this package as it is the old version of the package we're trying to build.
    ]]>
     </notes>
-    <packageUrl regex="true">^pkg:nuget/UKHO\.FileShareAdminClient@.*$</packageUrl>
-    <cvssBelow>10.0</cvssBelow>
+    <packageUrl regex="true">^pkg:nuget/UKHO\.FileShareClient@.*$</packageUrl>
+    <cpe>cpe:/a:file:file</cpe>
   </suppress>
   <suppress>
     <notes>

--- a/Tests/IntegrationTests/FileShareClientIntegrationTests/FileShareAdminClientTests.cs
+++ b/Tests/IntegrationTests/FileShareClientIntegrationTests/FileShareAdminClientTests.cs
@@ -111,6 +111,7 @@ namespace FileShareClientIntegrationTests
             {
                 Assert.That(result.IsSuccess, Is.True);
                 Assert.That(result.StatusCode, Is.EqualTo(204));
+                Assert.That(stream.CanSeek, Is.True);
             });
 
             await CommitBatchAsync(_batchHandle);

--- a/Tests/IntegrationTests/FileShareClientIntegrationTests/FileShareClientIntegrationTests.csproj
+++ b/Tests/IntegrationTests/FileShareClientIntegrationTests/FileShareClientIntegrationTests.csproj
@@ -7,17 +7,17 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.3">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="8.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.66.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.67.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.5.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Tests/UnitTests/FileShareAdminClientTests/AddFilesToBatchTests.cs
+++ b/Tests/UnitTests/FileShareAdminClientTests/AddFilesToBatchTests.cs
@@ -154,7 +154,12 @@ namespace FileShareAdminClientTests
                 $"PUT:/batch/{expectedBatchId}/files/{filename2}"
             };
             var actualRequests = _lastRequestUris.Select(x => $"{x.HttpMethod}:{x.Uri?.AbsolutePath}");
-            Assert.That(actualRequests, Is.EqualTo(expectedRequests));
+            Assert.Multiple(() =>
+            {
+                Assert.That(actualRequests, Is.EqualTo(expectedRequests));
+                Assert.That(stream1.CanSeek, Is.True);
+                Assert.That(stream2.CanSeek, Is.True);
+            });
         }
 
         [Test]
@@ -186,7 +191,12 @@ namespace FileShareAdminClientTests
                 $"PUT:/batch/{expectedBatchId}/files/{filename2}"
             };
             var actualRequests = _lastRequestUris.Select(x => $"{x.HttpMethod}:{x.Uri?.AbsolutePath}");
-            Assert.That(actualRequests, Is.EqualTo(expectedRequests));
+            Assert.Multiple(() =>
+            {
+                Assert.That(actualRequests, Is.EqualTo(expectedRequests));
+                Assert.That(stream1.CanSeek, Is.True);
+                Assert.That(stream2.CanSeek, Is.True);
+            });
         }
 
         [Test]
@@ -225,6 +235,8 @@ namespace FileShareAdminClientTests
                 Assert.That(actualRequests, Is.EqualTo(expectedRequests));
                 Assert.That(addFile1Request, Does.Contain("\"Key\":\"fileAttributeKey1\",\"Value\":\"fileAttributeValue1\""));
                 Assert.That(addFile2Request, Does.Contain("\"Key\":\"fileAttributeKey2\",\"Value\":\"fileAttributeValue2\""));
+                Assert.That(stream1.CanSeek, Is.True);
+                Assert.That(stream2.CanSeek, Is.True);
             });
         }
 
@@ -264,6 +276,8 @@ namespace FileShareAdminClientTests
                 Assert.That(actualRequests, Is.EqualTo(expectedRequests));
                 Assert.That(addFile1Request, Does.Contain("\"Key\":\"fileAttributeKey1\",\"Value\":\"fileAttributeValue1\""));
                 Assert.That(addFile2Request, Does.Contain("\"Key\":\"fileAttributeKey2\",\"Value\":\"fileAttributeValue2\""));
+                Assert.That(stream1.CanSeek, Is.True);
+                Assert.That(stream2.CanSeek, Is.True);
             });
         }
 
@@ -297,6 +311,7 @@ namespace FileShareAdminClientTests
             {
                 Assert.That(actualRequests, Is.EqualTo(expectedRequests));
                 Assert.That(writeBlockFileModel?.BlockIds, Is.EqualTo(expectedBlockIds));
+                Assert.That(stream1.CanSeek, Is.True);
             });
         }
 
@@ -330,6 +345,7 @@ namespace FileShareAdminClientTests
             {
                 Assert.That(actualRequests, Is.EqualTo(expectedRequests));
                 Assert.That(writeBlockFileModel?.BlockIds, Is.EqualTo(expectedBlockIds));
+                Assert.That(stream1.CanSeek, Is.True);
             });
         }
 
@@ -355,6 +371,7 @@ namespace FileShareAdminClientTests
                 Assert.That(progressReports, Has.Count.EqualTo(4));
                 Assert.That(progressReports.Select(r => r.blocksComplete), Is.EqualTo(expectedBlocksComplete));
                 Assert.That(progressReports.Select(r => r.totalBlockCount), Is.EqualTo(expectedTotalBlockCount));
+                Assert.That(stream1.CanSeek, Is.True);
             });
         }
 
@@ -380,6 +397,7 @@ namespace FileShareAdminClientTests
                 Assert.That(progressReports, Has.Count.EqualTo(4));
                 Assert.That(progressReports.Select(r => r.blocksComplete), Is.EqualTo(expectedBlocksComplete));
                 Assert.That(progressReports.Select(r => r.totalBlockCount), Is.EqualTo(expectedTotalBlockCount));
+                Assert.That(stream1.CanSeek, Is.True);
             });
         }
 
@@ -401,6 +419,7 @@ namespace FileShareAdminClientTests
             {
                 Assert.That(_fakeFssHttpClientFactory.HttpClient.DefaultRequestHeaders.Authorization.Scheme, Is.EqualTo("bearer"));
                 Assert.That(_fakeFssHttpClientFactory.HttpClient.DefaultRequestHeaders.Authorization.Parameter, Is.EqualTo(DUMMY_ACCESS_TOKEN));
+                Assert.That(stream1.CanSeek, Is.True);
             });
         }
     }

--- a/Tests/UnitTests/FileShareAdminClientTests/FileShareAdminClientTests.csproj
+++ b/Tests/UnitTests/FileShareAdminClientTests/FileShareAdminClientTests.csproj
@@ -10,14 +10,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.3">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="8.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.5.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Tests/UnitTests/FileShareClientTests/FileShareClientTests.csproj
+++ b/Tests/UnitTests/FileShareClientTests/FileShareClientTests.csproj
@@ -10,14 +10,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.3">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="8.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.5.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Tests/UnitTests/FileShareClientTestsCommon/FileShareClientTestsCommon.csproj
+++ b/Tests/UnitTests/FileShareClientTestsCommon/FileShareClientTestsCommon.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
-    <PackageReference Include="System.Text.Json" Version="9.0.0" />
+    <PackageReference Include="System.Text.Json" Version="9.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
#### PR Classification
Bug fix and dependency updates.

#### PR Summary
This pull request addresses a bug related to stream handling and updates several package dependencies.
- `FileShareApiAdminClient.cs`: Modified `CryptoStream` constructor to include `leaveOpen` parameter set to `true`.
- `AddFilesToBatchTests.cs`: Added assertions to check if streams can seek.
- Updated `FileShareClient.csproj`, `FileShareClientIntegrationTests.csproj`, `FileShareAdminClientTests.csproj`, `FileShareClientTests.csproj`, and `FileShareClientTestsCommon.csproj` to upgrade various package dependencies.
