### PR TITLE
Feature/275599 File share dot net client added upgraded support for .Net10 and .Net9/main

### DIFF
--- a/FileShareAdminClient/FileShareAdminClient.csproj
+++ b/FileShareAdminClient/FileShareAdminClient.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;netstandard2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0;netstandard2.1;net48</TargetFrameworks>
     <RootNamespace>UKHO.FileShareAdminClient</RootNamespace>
     <PackageProjectUrl>https://github.com/UKHO/file-share-dotnet-client</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/FileShareClient/FileShareClient.csproj
+++ b/FileShareClient/FileShareClient.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;netstandard2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0;netstandard2.1;net48</TargetFrameworks>
     <RootNamespace>UKHO.FileShareClient</RootNamespace>
     <PackageProjectUrl>https://github.com/UKHO/file-share-dotnet-client</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Tests/IntegrationTests/FileShareClientIntegrationTests/FileShareClientIntegrationTests.csproj
+++ b/Tests/IntegrationTests/FileShareClientIntegrationTests/FileShareClientIntegrationTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net48</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0;net48</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <IsPackable>false</IsPackable>

--- a/Tests/UnitTests/FileShareAdminClientTests/AddFilesToBatchTests.cs
+++ b/Tests/UnitTests/FileShareAdminClientTests/AddFilesToBatchTests.cs
@@ -82,7 +82,7 @@ namespace FileShareAdminClientTests
                     Assert.That(ex.ParamName, Is.EqualTo("stream"));
 #if NET48
                     Assert.That(ex.Message, Is.EqualTo("The stream must be seekable.\r\nParameter name: stream"));
-#elif NET8_0
+#elif NET8_0 || NET9_0 || NET10_0
                     Assert.That(ex.Message, Is.EqualTo("The stream must be seekable. (Parameter 'stream')"));
 #else
                     Assert.Fail("Framework not catered for.");                    
@@ -116,7 +116,7 @@ namespace FileShareAdminClientTests
                     Assert.That(ex.ParamName, Is.EqualTo("stream"));
 #if NET48
                     Assert.That(ex.Message, Is.EqualTo("The stream must be seekable.\r\nParameter name: stream"));
-#elif NET8_0
+#elif NET8_0 || NET9_0 || NET10_0
                     Assert.That(ex.Message, Is.EqualTo("The stream must be seekable. (Parameter 'stream')"));
 #else
                     Assert.Fail("Framework not catered for.");                    

--- a/Tests/UnitTests/FileShareAdminClientTests/FileShareAdminClientTests.csproj
+++ b/Tests/UnitTests/FileShareAdminClientTests/FileShareAdminClientTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net48</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0;net48</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
 

--- a/Tests/UnitTests/FileShareClientTests/FileShareClientTests.csproj
+++ b/Tests/UnitTests/FileShareClientTests/FileShareClientTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net48</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0;net48</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
 

--- a/Tests/UnitTests/FileShareClientTestsCommon/FileShareClientTestsCommon.csproj
+++ b/Tests/UnitTests/FileShareClientTestsCommon/FileShareClientTestsCommon.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net48</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0;net48</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <IsPackable>false</IsPackable>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,9 +24,9 @@ variables:
 - name: UKHOAssemblyProduct
   value: "File Share Dotnet Client"
 - name: SdkVersion
-  value: "8.0.x"
+  value: "10.0.x"
 - name: DotNetVersion
-  value: net8.0
+  value: net10.0
 - name: DotNetFrameworkVersion
   value: net48
 
@@ -171,7 +171,13 @@ stages:
     - group: Client Library Integration Tests
     steps:
     - checkout: none
-  
+
+    - task: UseDotNet@2
+      displayName: 'Use .NET $(SdkVersion) sdk'
+      inputs:
+        packageType: sdk
+        version: $(SdkVersion)
+
     - download: current
       displayName: Download integration tests
       artifact: IntegrationTests


### PR DESCRIPTION
This pull request updates the project to add support for .NET 9.0 and .NET 10.0 across all main libraries, test projects, and the build pipeline. Additionally, it updates unit tests to recognize the new frameworks when checking exception messages. These changes ensure compatibility with the latest .NET versions and keep the build and test infrastructure up to date.

**.NET Version Support Updates:**

* All main library and test project files (`.csproj`) now target `net10.0` and `net9.0` in addition to existing frameworks, ensuring the codebase is compatible with the latest .NET releases. [[1]](diffhunk://#diff-a670c3a188f2e933100eb2b7f9e153b780cc345f5c877d9a98ad57ef896d333eL1-R4) [[2]](diffhunk://#diff-ca5b3873e580f0d6167b372635b0f51bdc9db22fe0ace8ccd3d3660e7615da6cL4-R4) [[3]](diffhunk://#diff-5f95f8931a12da09c4733941b93c01badeea3b2b18981205b4dcb0d94c1d04b7L3-R3) [[4]](diffhunk://#diff-2dfb5da32a1affc6ccd2ff2142ac1036fe2d7d99067186c5408f579e48bc7b04L4-R4) [[5]](diffhunk://#diff-42eed4ef08f0c09023fa2b89146e26ee649fb2456e942c04517f288da634207aL4-R4) [[6]](diffhunk://#diff-2c13e27d103742e6861ddae7a871e774953bded199df184776a8a108b8550acdL4-R4)
* The Azure Pipelines configuration is updated to use .NET SDK 10.0.x and sets the default target framework to `net10.0`.
* The pipeline now explicitly installs the required .NET SDK version before running tests and builds.

**Test Improvements:**

* Unit tests in `AddFilesToBatchTests.cs` now correctly handle and assert exception messages for .NET 9.0 and 10.0, in addition to 8.0 and 4.8. [[1]](diffhunk://#diff-2adc0d5ae4084e51788ee6ba5e9e8a3403a3529fe023591c39472c1732be394dL85-R85) [[2]](diffhunk://#diff-2adc0d5ae4084e51788ee6ba5e9e8a3403a3529fe023591c39472c1732be394dL119-R119)